### PR TITLE
Lazy load Three.js only for PC version

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,5 @@
 </head>
 <body class="text-gray-200 font-sans antialiased">
   <app-root></app-root>
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS3DRenderer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove static Three.js-related scripts from `index.html`
- dynamically load Three.js, OrbitControls, and CSS3DRenderer when user activates PC version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4e98c17f08325b2335c28999939f0